### PR TITLE
Various updates

### DIFF
--- a/convert_from_telescope/result_merge.py
+++ b/convert_from_telescope/result_merge.py
@@ -38,18 +38,35 @@ class TelescopeResultMerger(object):
       merged by group.
 
     Returns:
-      (list) A list of MergedTelescopeResultReader objects where each object
-      corresponds to a group of results.
+    (dict) A dictionary of results, keyed by group key, then by metric name.
+    For example:
+    {
+      'lga01_comcast': {
+        'download_throughput': [
+          (<datetime-2014-10-01>, 24.5),
+          (<datetime-2014-10-02>, 24.5),
+          (<datetime-2014-10-03>, 24.5),
+          ...
+          ],
+        'upload_throughput': ...,
+        },
+      'sea01_verizon': {
+        'download_throughput': ...,
+        'upload_throughput': ...,
+        },
+      'mia02_twc': ...,
+      ...
+    }
     """
-    reader_groups = collections.defaultdict(lambda: [])
+    reader_groups = collections.defaultdict(
+        lambda: collections.defaultdict(
+            lambda: telescope_data_parser.MergedTelescopeResultReader()))
     for result_reader in result_readers:
-      key = self._create_group_key(result_reader.get_metadata())
-      reader_groups[key].append(result_reader)
-    merged_readers = []
-    for result_reader_group in reader_groups.itervalues():
-      merged_readers.append(telescope_data_parser.MergedTelescopeResultReader(
-          result_reader_group))
-    return merged_readers
+      metadata = result_reader.get_metadata()
+      key = self._create_group_key(metadata)
+      metric_name = metadata['metric_name']
+      reader_groups[key][metric_name].add_reader(result_reader)
+    return reader_groups
 
   def _create_group_key(self, metadata):
     raise NotImplementedError('Subclasses must implement this function.')

--- a/convert_from_telescope/result_merge_test.py
+++ b/convert_from_telescope/result_merge_test.py
@@ -21,50 +21,76 @@ import mock
 import result_merge
 
 
+def _get_mock_readers():
+  mock_readers = [mock.Mock() for _ in range(6)]
+  mock_readers[0].get_metadata.return_value = {
+      'site_name': 'lga01',
+      'metro': 'lga',
+      'isp': 'comcast',
+      'metric_name': 'download_throughput',
+      }
+  mock_readers[1].get_metadata.return_value = {
+      'site_name': 'lga01',
+      'metro': 'lga',
+      'isp': 'comcast',
+      'metric_name': 'download_throughput',
+      }
+  mock_readers[2].get_metadata.return_value = {
+      'site_name': 'lga01',
+      'metro': 'lga',
+      'isp': 'comcast',
+      'metric_name': 'average_rtt',
+      }
+  mock_readers[3].get_metadata.return_value = {
+      'site_name': 'sea01',
+      'metro': 'sea',
+      'isp': 'verizon',
+      'metric_name': 'upload_throughput',
+      }
+  mock_readers[4].get_metadata.return_value = {
+      'site_name': 'sea01',
+      'metro': 'sea',
+      'isp': 'verizon',
+      'metric_name': 'upload_throughput',
+      }
+  mock_readers[5].get_metadata.return_value = {
+      'site_name': 'sea01',
+      'metro': 'sea',
+      'isp': 'comcast',
+      'metric_name': 'download_throughput',
+      }
+  return mock_readers
+
 class PerSiteTelescopeResultMergerTest(unittest.TestCase):
 
   def test_merge_readers_by_site(self):
-    mock_readers = [mock.Mock() for _ in range(5)]
-    mock_readers[0].get_metadata.return_value = {
-        'site_name': 'lga01', 'isp': 'comcast'}
-    mock_readers[1].get_metadata.return_value = {
-        'site_name': 'lga01', 'isp': 'comcast'}
-    mock_readers[2].get_metadata.return_value = {
-        'site_name': 'sea01', 'isp': 'verizon'}
-    mock_readers[3].get_metadata.return_value = {
-        'site_name': 'sea01', 'isp': 'verizon'}
-    mock_readers[4].get_metadata.return_value = {
-        'site_name': 'sea01', 'isp': 'comcast'}
-
     merger = result_merge.PerSiteTelescopeResultMerger()
-    merged_readers = merger.merge_results(mock_readers)
+    merged_readers = merger.merge_results(_get_mock_readers())
 
-    # Readers should be grouped into three merged readers: lga01-comcast,
-    # sea01-comcast, and sea01-verizon.
-    self.assertEqual(3, len(merged_readers))
+    keys_expected = ('lga01_comcast', 'sea01_comcast', 'sea01_verizon')
+    self.assertItemsEqual(keys_expected, merged_readers.keys())
+    self.assertItemsEqual(('download_throughput', 'average_rtt'),
+                          merged_readers['lga01_comcast'].keys())
+    self.assertItemsEqual(('download_throughput',),
+                          merged_readers['sea01_comcast'].keys())
+    self.assertItemsEqual(('upload_throughput',),
+                          merged_readers['sea01_verizon'].keys())
 
 
 class PerMetroTelescopeResultMergerTest(unittest.TestCase):
 
   def test_merge_readers_by_metro(self):
-    mock_readers = [mock.Mock() for _ in range(5)]
-    mock_readers[0].get_metadata.return_value = {
-        'metro': 'lga', 'isp': 'comcast'}
-    mock_readers[1].get_metadata.return_value = {
-        'metro': 'lga', 'isp': 'comcast'}
-    mock_readers[2].get_metadata.return_value = {
-        'metro': 'lga', 'isp': 'comcast'}
-    mock_readers[3].get_metadata.return_value = {
-        'metro': 'sea', 'isp': 'verizon'}
-    mock_readers[4].get_metadata.return_value = {
-        'metro': 'sea', 'isp': 'comcast'}
-
     merger = result_merge.PerMetroTelescopeResultMerger()
-    merged_readers = merger.merge_results(mock_readers)
+    merged_readers = merger.merge_results(_get_mock_readers())
 
-    # Readers should be grouped into three merged readers: lga-comcast,
-    # sea-comcast, and sea-verizon.
-    self.assertEqual(3, len(merged_readers))
+    keys_expected = ('LGA_comcast', 'SEA_comcast', 'SEA_verizon')
+    self.assertItemsEqual(keys_expected, merged_readers.keys())
+    self.assertItemsEqual(('download_throughput', 'average_rtt'),
+                          merged_readers['LGA_comcast'].keys())
+    self.assertItemsEqual(('download_throughput',),
+                          merged_readers['SEA_comcast'].keys())
+    self.assertItemsEqual(('upload_throughput',),
+                          merged_readers['SEA_verizon'].keys())
 
 
 if __name__ == '__main__':

--- a/convert_from_telescope/result_merge_test.py
+++ b/convert_from_telescope/result_merge_test.py
@@ -22,7 +22,7 @@ import result_merge
 
 
 def _get_mock_readers():
-  mock_readers = [mock.Mock() for _ in range(6)]
+  mock_readers = [mock.Mock() for _ in range(7)]
   mock_readers[0].get_metadata.return_value = {
       'site_name': 'lga01',
       'metro': 'lga',
@@ -59,6 +59,12 @@ def _get_mock_readers():
       'isp': 'comcast',
       'metric_name': 'download_throughput',
       }
+  mock_readers[6].get_metadata.return_value = {
+      'site_name': 'sea02',
+      'metro': 'sea',
+      'isp': 'comcast',
+      'metric_name': 'download_throughput',
+      }
   return mock_readers
 
 class PerSiteTelescopeResultMergerTest(unittest.TestCase):
@@ -67,7 +73,8 @@ class PerSiteTelescopeResultMergerTest(unittest.TestCase):
     merger = result_merge.PerSiteTelescopeResultMerger()
     merged_readers = merger.merge_results(_get_mock_readers())
 
-    keys_expected = ('lga01_comcast', 'sea01_comcast', 'sea01_verizon')
+    keys_expected = ('lga01_comcast', 'sea01_comcast', 'sea01_verizon',
+                     'sea02_comcast')
     self.assertItemsEqual(keys_expected, merged_readers.keys())
     self.assertItemsEqual(('download_throughput', 'average_rtt'),
                           merged_readers['lga01_comcast'].keys())
@@ -75,6 +82,8 @@ class PerSiteTelescopeResultMergerTest(unittest.TestCase):
                           merged_readers['sea01_comcast'].keys())
     self.assertItemsEqual(('upload_throughput',),
                           merged_readers['sea01_verizon'].keys())
+    self.assertItemsEqual(('download_throughput',),
+                          merged_readers['sea02_comcast'].keys())
 
 
 class PerMetroTelescopeResultMergerTest(unittest.TestCase):

--- a/convert_from_telescope/sample_checking.py
+++ b/convert_from_telescope/sample_checking.py
@@ -246,6 +246,5 @@ class DataFileBlacklister(object):
       return
 
     with open(filename, 'r') as data_file:
-      telescope_data = result_reader.read_rows()
-      self._sample_counter.add_to_counts(metadata, telescope_data)
+      self._sample_counter.add_to_counts(metadata, result_reader)
 


### PR DESCRIPTION
I wrote a bunch of code over the holiday slowdown thinking that I could use git magic later to group the commits into neat, cohesive pull requests, but it turns out it's not so easy to do that so my pull requests got a little convoluted and I apologize. This pull request does the following:

* Fixes sample_checking.py to use the `SingleTelescopeResultReader` class to parse Telescope input files (previously it used the `parse_filename_for_metadata` and `parse_data_file` but these are now module private - insofar as naming conventionsl let us pretend things are private).

* Changes `TelescopeResultReader` so that it's an iterator over all the parsed rows (like the Python file `open` API is with lines of text) instead of the caller having to call `read_rows`. Now functions that are expecting a list of raw Telescope data rows can receive a `TelescopeResultReader` and not know the difference.
  * As a result of the above, we update `sample_checking.py` to just pass along a `TelescopeResultReader` object when it calls `add_to_counts()` instead of having to explicitly call `read_rows`.

You're welcome to review the pull request commit-by-commit if it's easier (though I will generally try to prevent making pull requests where you have to do that because it's usually a pain)