### PR TITLE
Refactor data path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.pyc
-
+static/js/observatory/js/paths.js

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 mlab-observatory
 ================
+
+# Setup
+
+To bootstrap the environment, run:
+
+```
+python bootstrap_environment.py [environment_type]
+```
+
+Where `environment_type` is either `staging` or `live`.

--- a/environment_bootstrap.py
+++ b/environment_bootstrap.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+#
+# Copyright 2015 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+"""Configure Observatory based on the type of environment this is."""
+
+
+def setup_environment(environment_type):
+  link_name = 'static/js/observatory/js/paths.js'
+  if environment_type == 'staging':
+    os.symlink('paths.js.staging', link_name)
+  elif environment_type == 'live':
+    os.symlink('paths.js.live', link_name)
+  else:
+    print 'Error: Invalid environment type'
+    sys.exit(-1)
+
+
+def main(args):
+  setup_environment(args.environment_type)
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+      prog='Observatory Environment Bootstrapper',
+      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument('environment_type',
+                      choices=['staging', 'live'],
+                      help='The type of environment to configure.')
+  main(parser.parse_args())
+

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
 	<script src="static/js/observatory/vendor/bootstrap/bootstrap-select.min.js"></script>
 
 	<script src="static/js/observatory/js/utils.js"></script>
+	<script src="static/js/observatory/js/paths.js"></script>
 	<script src="static/js/observatory/js/dataLoader.js"></script>
 	<script src="static/js/observatory/js/controls.js"></script>
 	<script src="static/js/observatory/js/timeControl.js"></script>

--- a/static/js/observatory/js/dataLoader.js
+++ b/static/js/observatory/js/dataLoader.js
@@ -3,33 +3,33 @@ file that handles all data loading
 */
 (function() {
   var colorMap;
-  var exports = new EventEmitter()
-  var metadatafolder = '/mlab-observatory/static/observatory/metadata/'
+  var exports = new EventEmitter();
+  var metadatafolder = mlabOpenInternet.paths.dataRoot + 'metadata/';
 
-  var mapFile = metadatafolder + "codeMap.csv"
-  var validExploreCodesFile = metadatafolder + 'validExploreKeys.txt'
-  var validCompareCodesFile = metadatafolder + 'validCompareKeys.txt'
-  var metricFile = metadatafolder + 'metrics.json'
+  var mapFile = metadatafolder + 'codeMap.csv';
+  var validExploreCodesFile = metadatafolder + 'validExploreKeys.txt';
+  var validCompareCodesFile = metadatafolder + 'validCompareKeys.txt';
+  var metricFile = metadatafolder + 'metrics.json';
 
-  var dataPath = '/mlab-observatory/static/observatory/data/'
+  var dataPath = mlabOpenInternet.paths.dataRoot + 'data/';
   var validExploreCodes = [];
-  var validCompareCodes = []
-  var ispsBySite = {}
+  var validCompareCodes = [];
+  var ispsBySite = {};
   var validISPs = [];
   var validSiteNames = [];
-  var validMetroRegions = []
-  var metroRegionToMLabPrefix = {}
+  var validMetroRegions = [];
+  var metroRegionToMLabPrefix = {};
   var siteMappings = null;
   var metrics = null;
   var dailyDataByCode = {};
   var hourlyDataByCode = {};
   var dailyCompareDataByCode = {};
   var hourlyCompareDataByCode = {};
-  var mlabSitesByCode = {}
+  var mlabSitesByCode = {};
   var ispNameMap;
-  var minSampleSize = 30
-  var regionsToIgnore = []
-  var filenameToColorMap = {}
+  var minSampleSize = 30;
+  var regionsToIgnore = [];
+  var filenameToColorMap = {};
   var loadingDiv;
 
   //kick off data loading

--- a/static/js/observatory/js/paths.js.live
+++ b/static/js/observatory/js/paths.js.live
@@ -4,11 +4,11 @@ Specifies commonly used data paths within Observatory.
 */
 (function() {
   var exports = new EventEmitter();
-  exports.dataRoot = 'http://storage.googleapis.com/mlab-observatory/'
+  exports.dataRoot = 'http://storage.googleapis.com/mlab-observatory/';
 
   if (!window.mlabOpenInternet) {
-    window.mlabOpenInternet = {}
+    window.mlabOpenInternet = {};
   }
 
   window.mlabOpenInternet.paths = exports;
-})()
+})():

--- a/static/js/observatory/js/paths.js.live
+++ b/static/js/observatory/js/paths.js.live
@@ -1,0 +1,14 @@
+/*
+Specifies commonly used data paths within Observatory.
+(Version for LIVE instance of Observatory)
+*/
+(function() {
+  var exports = new EventEmitter();
+  exports.dataRoot = 'http://storage.googleapis.com/mlab-observatory/'
+
+  if (!window.mlabOpenInternet) {
+    window.mlabOpenInternet = {}
+  }
+
+  window.mlabOpenInternet.paths = exports;
+})()

--- a/static/js/observatory/js/paths.js.staging
+++ b/static/js/observatory/js/paths.js.staging
@@ -1,0 +1,14 @@
+/*
+Specifies commonly used data paths within Observatory.
+(Version for STAGING version of Observatory)
+*/
+(function() {
+  var exports = new EventEmitter();
+  exports.dataRoot = 'http://storage.googleapis.com/mlab-observatory-staging/'
+
+  if (!window.mlabOpenInternet) {
+    window.mlabOpenInternet = {}
+  }
+
+  window.mlabOpenInternet.paths = exports;
+})()

--- a/static/js/observatory/js/paths.js.staging
+++ b/static/js/observatory/js/paths.js.staging
@@ -4,11 +4,11 @@ Specifies commonly used data paths within Observatory.
 */
 (function() {
   var exports = new EventEmitter();
-  exports.dataRoot = 'http://storage.googleapis.com/mlab-observatory-staging/'
+  exports.dataRoot = 'http://storage.googleapis.com/mlab-observatory-staging/';
 
   if (!window.mlabOpenInternet) {
-    window.mlabOpenInternet = {}
+    window.mlabOpenInternet = {};
   }
 
   window.mlabOpenInternet.paths = exports;
-})()
+})();


### PR DESCRIPTION
This change is to facilitate using Observatory in an isolated staging environment that doesn't need to touch the production data. To do that, we create a single variable that indicates the root of the data directory and we put this variable in its own path.js file.

This also includes a bootstrap_environment.js file that the user runs when first setting up the environment after checking out the repo which creates the correct file depending on whether this is for a staging or production environment.